### PR TITLE
Add markdown-it-emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-vue": "^5.2.3",
     "markdown-it-anchor": "^5.2.7",
+	"markdown-it-emoji": "^1.4.0",
     "node-sass": "^4.13.1",
     "sass-loader": "^7.3.1",
     "vue-markdown-loader": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-vue": "^5.2.3",
     "markdown-it-anchor": "^5.2.7",
-	"markdown-it-emoji": "^1.4.0",
+    "markdown-it-emoji": "^1.4.0",
     "node-sass": "^4.13.1",
     "sass-loader": "^7.3.1",
     "vue-markdown-loader": "^2.4.1",

--- a/vue.config.js
+++ b/vue.config.js
@@ -22,7 +22,8 @@ module.exports = {
         raw: true,
         linkify: true,
         use: [
-          require('markdown-it-anchor')
+          require('markdown-it-anchor'),
+		  require('markdown-it-emoji')
         ]
       })
   },

--- a/vue.config.js
+++ b/vue.config.js
@@ -23,7 +23,7 @@ module.exports = {
         linkify: true,
         use: [
           require('markdown-it-anchor'),
-		  require('markdown-it-emoji')
+          require('markdown-it-emoji')
         ]
       })
   },


### PR DESCRIPTION
The `markdown-it-emoji` plugin allows us to parse almost all common emojis in the wiki. Some GitHub specific ones (like `:octocat:`) are still not parseable trough this.