### PR TITLE
Add extensions to Download page

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -111,8 +111,8 @@ export default new Vuex.Store({
       state.downloads = downloads;
     },
     
-    addExtension: (state, { extension, extensionName }) => {
-      state.extensions[extensionName] = extension;
+    setExtensions: (state, extensions) => {
+      state.extensions = extensions;
     },
 
     setDiscordUserCount: (state, discordUserCount) => {
@@ -352,19 +352,20 @@ export default new Vuex.Store({
         })
         .catch(console.error);
         
-      const extensions = [ 'extension-legacy-api', 'extension-default-assignments' ];
-      extensions.forEach(( extensionId ) => {
+      const extensionIds = [ 'extension-legacy-api', 'extension-default-assignments' ];
+      let extensions = {};
+      extensionIds.forEach(( extensionId ) => {
         axios.get(`https://ci.lucko.me/job/${extensionId}/lastSuccessfulBuild/api/json?tree=url,artifacts[fileName,relativePath]`)
           .then((response) => {
             response.data.artifacts.forEach((artifact) => {
-              const extension = `${response.data.url}artifact/${artifact.relativePath}`;
-              const extensionName = `${response.data.url.split('/')[4]}`;
-            
-              commit('addExtension', { extension, extensionName });
+              const extension = `${response.data.url.split('/')[4]}`;
+              
+              extensions[extension] = `${response.data.url}artifact/${artifact.relativePath}`;
             });
           })
           .catch(console.error);
       });
+      commit('setExtensions', extensions);
 
       axios.get('https://discordapp.com/api/invites/luckperms?with_counts=true')
         .then((response) => {

--- a/src/store.js
+++ b/src/store.js
@@ -18,6 +18,10 @@ export default new Vuex.Store({
       sponge: null,
       velocity: null,
     },
+    extensions: {
+      'extension-legacy-api': null,
+      'extension-default-assignments': null,
+    },
     discordUserCount: null,
     patreonCount: null,
     editor: {
@@ -40,6 +44,8 @@ export default new Vuex.Store({
     version: (state) => state.version,
 
     downloads: (state) => state.downloads,
+    
+    extensions: (state) => state.extensions,
 
     discordUserCount: (state) => state.discordUserCount,
 
@@ -103,6 +109,10 @@ export default new Vuex.Store({
 
     setDownloads: (state, downloads) => {
       state.downloads = downloads;
+    },
+    
+    addExtension: (state, { extension, extensionName }) => {
+      state.extensions[extensionName] = extension;
     },
 
     setDiscordUserCount: (state, discordUserCount) => {
@@ -335,11 +345,26 @@ export default new Vuex.Store({
           let downloads = {};
           response.data.artifacts.forEach((artifact) => {
             const download = artifact.relativePath.split('/')[0];
+            
             downloads[download] = `${response.data.url}artifact/${artifact.relativePath}`;
           });
           commit('setDownloads', downloads);
         })
         .catch(console.error);
+        
+      const extensions = [ 'extension-legacy-api', 'extension-default-assignments' ];
+      extensions.forEach(( extensionId ) => {
+        axios.get(`https://ci.lucko.me/job/${extensionId}/lastSuccessfulBuild/api/json?tree=url,artifacts[fileName,relativePath]`)
+          .then((response) => {
+            response.data.artifacts.forEach((artifact) => {
+              const extension = `${response.data.url}artifact/${artifact.relativePath}`;
+              const extensionName = `${response.data.url.split('/')[4]}`;
+            
+              commit('addExtension', { extension, extensionName });
+            });
+          })
+          .catch(console.error);
+      });
 
       axios.get('https://discordapp.com/api/invites/luckperms?with_counts=true')
         .then((response) => {

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -84,8 +84,14 @@
     <section class="hero">
       <h1>Extensions</h1>
     </section>
+    <div class="container" style="margin-bottom: -80px;">
+      <div class="resources">
+        <div style="width: 100%;">
+          <p style="text-align: center; font-size: 24px;">Extensions can modify the behaviour of LuckPerms, you can read more about them <a href="/wiki/Extensions">on the wiki</a></p>
+        </div>
+      </div>
+    </div>
     <div class="container">
-      <p style="text-align: center; font-size: 24px;">Extensions can modify the behaviour of LuckPerms, you can read more about them <a href="/wiki/Extensions">on the wiki</a></p>
       <div class="resources">
         <div style="width: auto; padding-top: 0;">
           <table>

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -74,7 +74,7 @@
           <h2>Having trouble installing?</h2>
           <ul>
             <li>Make sure to check your console for any errors - especially during start up</li>
-            <li>Check the <a href="https://github.com/lucko/LuckPerms/wiki" target="_blank">wiki</a> to see if you missed any important steps during setup</li>
+            <li>Check the <a href="/wiki" target="_blank">wiki</a> to see if you missed any important steps during setup</li>
             <li>Delete the <code>libs</code> folder and restart the server to let it regenerate, sometimes this may fix the problem</li>
             <li>If all else fails, join our <a href="https://discord.gg/luckperms" target="_blank">Discord</a> to get some support</li>
           </ul>

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -86,9 +86,21 @@
       <div class="container">
         <div class="resources">
           <div>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dolor doloribus eos facilis fuga harum id illum iste, laboriosam molestiae nam necessitatibus non obcaecati quas repellat temporibus veritatis vitae, voluptates voluptatum.</p>
+            <a :href="extensions['extension-legacy-api']" class="resource">
+              <span>
+                <font-awesome icon="arrow-alt-circle-down" />
+                Legacy API Extension
+              </span>
+              <small>LuckPerms 5.0 and above</small>
+            </a>
+            <a :href="extensions['extension-default-assignments']" class="resource">
+              <span>
+                <font-awesome icon="arrow-alt-circle-down" />
+                Default Assignments Extension
+              </span>
+              <small>LuckPerms 5.0 and above</small>
+            </a>
           </div>
-          <div></div>
         </div>
       </div>
     </div>
@@ -113,6 +125,7 @@ export default {
     };
   },
   computed: {
+    extensions() { return this.$store.getters.extensions },
     downloads() { return this.$store.getters.downloads },
     version() { return this.$store.getters.version }
   },

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -74,7 +74,7 @@
           <h2>Having trouble installing?</h2>
           <ul>
             <li>Make sure to check your console for any errors - especially during start up</li>
-            <li>Check the <a href="/wiki" target="_blank">wiki</a> to see if you missed any important steps during setup</li>
+            <li>Check the <router-link to="/wiki">wiki</router-link> to see if you missed any important steps during setup</li>
             <li>Delete the <code>libs</code> folder and restart the server to let it regenerate, sometimes this may fix the problem</li>
             <li>If all else fails, join our <a href="https://discord.gg/luckperms" target="_blank">Discord</a> to get some support</li>
           </ul>

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -80,45 +80,45 @@
           </ul>
         </div>
       </section>
-      <section class="hero">
-        <h1>Extensions</h1>
-      </section>
-      <div class="container">
-        <div class="resources">
-          <div style="width: auto;">
-            <table>
-              <tr>
-                <td>
-                  <a :href="extensions['extension-legacy-api']" class="resource">
-                    <span>
-                      <font-awesome icon="arrow-alt-circle-down" />
-                      Legacy API Extension
-                    </span>
-                    <small>LuckPerms 5.0 and above</small>
-                  </a>
-                </td>
-                <td>
-                  <p>Allows some common API methods to be used by plugins that haven't upgraded to v5 version of the api yet.</p>
-                  <p>Check out the <a href="/wiki/Extensions#extension-legacy-api">wiki section</a> for more information!</p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a :href="extensions['extension-default-assignments']" class="resource">
-                    <span>
-                      <font-awesome icon="arrow-alt-circle-down" />
-                      Default Assignments Extension
-                    </span>
-                    <small>LuckPerms 5.0 and above</small>
-                  </a>
-                </td>
-                <td>
-                  <p>Allows for other ways for making <a href="/wiki/Default-Groups">Default Groups</a> if the workarounds are not possible.</p>
-                  <p>Check out the <a href="/wiki/Extensions#extension-default-assignments">wiki section</a> for more information! See also <a href="/wiki/Default-Groups#configure-default-assignments">this section</a> about default groups!</p>
-                </td>
-              </tr>
-            </table>
-          </div>
+    </div>
+    <section class="hero">
+      <h1>Extensions</h1>
+    </section>
+    <div class="container">
+      <div class="resources">
+        <div style="width: auto;">
+          <table>
+            <tr>
+              <td>
+                <a :href="extensions['extension-legacy-api']" class="resource">
+                  <span>
+                    <font-awesome icon="arrow-alt-circle-down" />
+                    Legacy API Extension
+                  </span>
+                  <small>LuckPerms 5.0 and above</small>
+                </a>
+              </td>
+              <td>
+                <p>Allows some common API methods to be used by plugins that haven't upgraded to v5 version of the api yet.</p>
+                <p>Check out the <a href="/wiki/Extensions#extension-legacy-api">wiki section</a> for more information!</p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a :href="extensions['extension-default-assignments']" class="resource">
+                  <span>
+                    <font-awesome icon="arrow-alt-circle-down" />
+                    Default Assignments Extension
+                  </span>
+                  <small>LuckPerms 5.0 and above</small>
+                </a>
+              </td>
+              <td>
+                <p>Allows for other ways for making <a href="/wiki/Default-Groups">Default Groups</a> if the workarounds are not possible.</p>
+                <p>Check out the <a href="/wiki/Extensions#extension-default-assignments">wiki section</a> for more information! See also <a href="/wiki/Default-Groups#configure-default-assignments">this section</a> about default groups!</p>
+              </td>
+            </tr>
+          </table>
         </div>
       </div>
     </div>

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -85,8 +85,9 @@
       <h1>Extensions</h1>
     </section>
     <div class="container">
+      <p style="text-align: center; font-size: 24px;">Extensions can modify the behaviour of LuckPerms, you can read more about them <a href="/wiki/Extensions">on the wiki</a></p>
       <div class="resources">
-        <div style="width: auto;">
+        <div style="width: auto; padding-top: 0;">
           <table>
             <tr>
               <td>

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -85,21 +85,39 @@
       </section>
       <div class="container">
         <div class="resources">
-          <div>
-            <a :href="extensions['extension-legacy-api']" class="resource">
-              <span>
-                <font-awesome icon="arrow-alt-circle-down" />
-                Legacy API Extension
-              </span>
-              <small>LuckPerms 5.0 and above</small>
-            </a>
-            <a :href="extensions['extension-default-assignments']" class="resource">
-              <span>
-                <font-awesome icon="arrow-alt-circle-down" />
-                Default Assignments Extension
-              </span>
-              <small>LuckPerms 5.0 and above</small>
-            </a>
+          <div style="width: auto;">
+            <table>
+              <tr>
+                <td>
+                  <a :href="extensions['extension-legacy-api']" class="resource">
+                    <span>
+                      <font-awesome icon="arrow-alt-circle-down" />
+                      Legacy API Extension
+                    </span>
+                    <small>LuckPerms 5.0 and above</small>
+                  </a>
+                </td>
+                <td>
+                  <p>Allows some common API methods to be used by plugins that haven't upgraded to v5 version of the api yet.</p>
+                  <p>Check out the <a href="/wiki/Extensions#extension-legacy-api">wiki section</a> for more information!</p>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a :href="extensions['extension-default-assignments']" class="resource">
+                    <span>
+                      <font-awesome icon="arrow-alt-circle-down" />
+                      Default Assignments Extension
+                    </span>
+                    <small>LuckPerms 5.0 and above</small>
+                  </a>
+                </td>
+                <td>
+                  <p>Allows for other ways for making <a href="/wiki/Default-Groups">Default Groups</a> if the workarounds are not possible.</p>
+                  <p>Check out the <a href="/wiki/Extensions#extension-default-assignments">wiki section</a> for more information! See also <a href="/wiki/Default-Groups#configure-default-assignments">this section</a> about default groups!</p>
+                </td>
+              </tr>
+            </table>
           </div>
         </div>
       </div>
@@ -192,5 +210,14 @@ export default {
         white-space: nowrap;
       }
     }
+    
+    table {
+      border-spacing: 0 20px;
+    }
+    
+    td {
+      padding-left: 20px;
+    }
+    
   }
 </style>

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -87,7 +87,7 @@
     <div class="container extensions-description" >
       <div class="resources">
 				<div>
-					<p>Extensions can modify the behaviour of LuckPerms, you can read more about them <a href="/wiki/Extensions">on the wiki</a></p>
+					<p>Extensions can modify the behaviour of LuckPerms, you can read more about them <router-link to="/wiki/Extensions">on the wiki</router-link></p>
 				</div>
       </div>
     </div>
@@ -105,7 +105,7 @@
 				
 				<div>
           <p>Allows some common API methods to be used by plugins that haven't upgraded to v5 version of the api yet.</p>
-          <p>Check out the <a href="/wiki/Extensions#extension-legacy-api">wiki section</a> for more information!</p>
+          <p>Check out the <router-link to="/wiki/Extensions#extension-legacy-api">wiki section</router-link> for more information!</p>
 				</div>
 			</section>
 			<section class="resources">
@@ -120,8 +120,8 @@
 				</div>
 				
 				<div>
-					<p>Allows for other ways to make <a href="/wiki/Default-Groups">Default Groups</a> if the workarounds are not possible.</p>
-          <p>Check out the <a href="/wiki/Extensions#extension-default-assignments">wiki section</a> for more information! See also <a href="/wiki/Default-Groups#configure-default-assignments">this section</a> about configuring default assignments!</p>
+					<p>Allows for other ways to make <router-link to="/wiki/Default-Groups">Default Groups</router-link> if the workarounds are not possible.</p>
+          <p>Check out the <router-link to="/wiki/Extensions#extension-default-assignments">wiki section</router-link> for more information! See also <a href="/wiki/Default-Groups#configure-default-assignments">this section</a> about configuring default assignments!</p>
 				</div>
 			</section>
     </div>


### PR DESCRIPTION
Adds downloads for the extensions to the Download page.

## To-Do
- [x] Find out why it doesn't display "Extensions" directly
- [x] Add description for extensions in general
- [x] Add description for each extension

## What it looks like
![image](https://user-images.githubusercontent.com/43016900/79241562-7e170c80-7e73-11ea-831b-54a72bb6571d.png)
