### PR TITLE
Add copy symbol

### DIFF
--- a/src/views/Wiki.vue
+++ b/src/views/Wiki.vue
@@ -64,6 +64,10 @@
         padding-left: 1rem;
       }
     }
+    
+    .header-anchor {
+      display: none;
+    }
   }
 
   #article {
@@ -156,15 +160,23 @@
       }
 
       img {
+        max-width: 100%;
+        
         &:not([src$="png"]) {
           box-shadow: 0 0 1rem rgba(0,0,0,.2);
         }
       }
+      
+      .header-anchor {
+        text-decoration: none;
+        display: none;
+      }
+      
+      h2:hover > .header-anchor,
+      h3:hover > .header-anchor {
+        display: initial;
+      }
     }
-  }
-
-  img {
-	max-width: 100%;
   }
 
   :target {

--- a/src/views/Wiki.vue
+++ b/src/views/Wiki.vue
@@ -27,6 +27,11 @@
 	  background-color: $grey;
     height: 100%;
     flex-wrap: wrap;
+    
+    .header-anchor {
+      text-decoration: none;
+      display: none;
+    }
   }
 
   aside {
@@ -63,10 +68,6 @@
       ul {
         padding-left: 1rem;
       }
-    }
-    
-    .header-anchor {
-      display: none;
     }
   }
 
@@ -165,11 +166,6 @@
         &:not([src$="png"]) {
           box-shadow: 0 0 1rem rgba(0,0,0,.2);
         }
-      }
-      
-      .header-anchor {
-        text-decoration: none;
-        display: none;
       }
       
       h2:hover > .header-anchor,

--- a/vue.config.js
+++ b/vue.config.js
@@ -22,7 +22,10 @@ module.exports = {
         raw: true,
         linkify: true,
         use: [
-          require('markdown-it-anchor')
+          [require('markdown-it-anchor'), {
+            "permalink": true,
+            "permalinkSymbol": "🔗"
+          }]
         ]
       })
   },


### PR DESCRIPTION
Add a copy symbol to all level 2 and 3 header anchors. They will only appear in the actual wiki content (not the sidebar) and only if you hover over the corresponding header.

## How it looks like
**On the wiki:**
![image](https://user-images.githubusercontent.com/43016900/79325802-18c62880-7f12-11ea-8ab7-6052cf67f71d.png)
**On GitHub:**
![image](https://user-images.githubusercontent.com/43016900/79325892-3eebc880-7f12-11ea-81b9-117ab34beda2.png)
