### PR TITLE
Tree CSS fix

### DIFF
--- a/src/components/Tree/Branch.vue
+++ b/src/components/Tree/Branch.vue
@@ -82,6 +82,7 @@
       border: 0;
       padding: 0 .8rem;
       cursor: pointer;
+      margin-left: .2rem;
     }
   }
 </style>


### PR DESCRIPTION
When expanding a branch the `>` symbol will be outlined. But the left side of the oultine won't be shown. This PR fixes that.

## How it looks like:

**Before:**
![image](https://user-images.githubusercontent.com/43016900/80280453-5ee66d80-8704-11ea-9124-92bce5d9332e.png)


**After:**
![image](https://user-images.githubusercontent.com/43016900/80280427-437b6280-8704-11ea-9ea4-1344b67eb611.png)
