### PR TITLE
Small style changes for extensions

### DIFF
--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -83,14 +83,8 @@
     </div>
     <section class="hero">
       <h1>Extensions</h1>
+      <p>Extensions can modify the behaviour of LuckPerms, you can read more about them <router-link to="/wiki/Extensions">on the wiki</router-link></p>
     </section>
-    <div class="container extensions-description" >
-      <div class="resources">
-        <div>
-          <p>Extensions can modify the behaviour of LuckPerms, you can read more about them <router-link to="/wiki/Extensions">on the wiki</router-link></p>
-        </div>
-      </div>
-    </div>
     <div class="container extensions">
       <section class="resources">
         <div>
@@ -216,19 +210,6 @@ export default {
     
     .extensions section {
       margin-bottom: -8rem;
-    }
-    
-    .extensions-description {
-      margin-bottom: -8rem;
-    
-      .resources > div {
-        width: 100%;
-        
-        p {
-          text-align: center;
-          font-size: 1.5rem;
-        }
-      }
     }
   }
 </style>


### PR DESCRIPTION
Change the position of the extensions description text.

## How it looks like
**Before:**
![image](https://user-images.githubusercontent.com/43016900/81494846-25893280-92ac-11ea-8e82-b5ec39355e95.png)
**After:**
![image](https://user-images.githubusercontent.com/43016900/81494853-39cd2f80-92ac-11ea-8aa2-3f1b5f6c02b1.png)
