### PR TITLE
Ignore temporary NodeJS installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules
 dist
 
+# temporary NodeJS installation
+installer/.nvm
+
 # local env files
 .env.local
 .env.*.local


### PR DESCRIPTION
If no nodejs is installed on the system when the installer script is used a isolated, local and temporary NodeJS installation is being placed in the path `installer/.nvm`. This ignores that.