### PR TITLE
Add hide sponsor config option

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@
           <img alt="LuckPerms logo" src="@/assets/logo.png">
           <span>LuckPerms</span>
         </router-link>
-        <div v-if="!config.selfHosted" class="nav-message">
+        <div v-if="!(config.selfHosted || (config.hideSponsor || false))" class="nav-message">
           <a href="https://bisecthosting.com/luck" target="_blank">
             <img src="@/assets/bisect.svg" alt="Bisect Hosting">
             <span>


### PR DESCRIPTION
Adds an option to hide the sponsor, even if not self hosting.
Won't override the selfHosted option tough (selfHosted: true and hideSponsor: false will still not show the sponsor)

Not sure if @BrainStone wants to add it to the install script.