### PR TITLE
Add GitHub like anchor ids

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -29,6 +29,7 @@ module.exports = {
           [require('markdown-it-anchor'), {
             permalink: true,
             permalinkSymbol: '🔗',
+            slugify: (s) => String(s).trim().toLowerCase().replace(/\s+/g, '-').replace(/([^\w\-]+)/g, ''),
           }],
           // eslint-disable-next-line global-require
           require('markdown-it-emoji'),


### PR DESCRIPTION
This not just makes everything more easy, it also means the wiki should work like before.

Regex based on the [markdown-it-anchor package](https://github.com/valeriangalliat/markdown-it-anchor/blob/master/index.js#L1).