### PR TITLE
Exit early on errors

### DIFF
--- a/installer/common.sh
+++ b/installer/common.sh
@@ -192,13 +192,13 @@ check_nodejs() {
         echo
 
         export NVM_DIR="$INSTALLER_DIR/.nvm"
-        mkdir -p "$NVM_DIR"
+        mkdir -p "$NVM_DIR" || exit $?
 
         # Install NVM in local dir
         # https://github.com/nvm-sh/nvm
-        wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | PROFILE=/dev/null bash
-        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-        nvm use node
+        wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | PROFILE=/dev/null bash || exit $?
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" || exit $?
+        nvm use node || exit $?
     fi
 
     echo

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -92,7 +92,7 @@ setup_submodules() {
     echo "Downloading and updating submodules..."
     echo
 
-    git -C "$INSTALLER_DIR" submodule update --init --recursive
+    git -C "$INSTALLER_DIR" submodule update --init --recursive || exit $?
 
     echo
 }
@@ -118,8 +118,8 @@ install_prerequisites() {
         echo "Installing them now..."
         echo
 
-        sudo apt-get update
-        sudo apt-get install -y "${PACKAGES_TO_INSTALL[@]}"
+        sudo apt-get update || exit $?
+        sudo apt-get install -y "${PACKAGES_TO_INSTALL[@]}" || exit $?
     else
         echo "All packages installed!"
     fi
@@ -150,8 +150,8 @@ prepare_installation_location() {
     echo
 
     if [ ! -d "$BASE_DIR" ]; then
-        sudo mkdir "$BASE_DIR"
-        sudo chown "$USER:$GROUP" "$BASE_DIR"
+        sudo mkdir "$BASE_DIR" || exit $?
+        sudo chown "$USER:$GROUP" "$BASE_DIR" || exit $?
     fi
 
     cd "$BASE_DIR"
@@ -160,7 +160,7 @@ prepare_installation_location() {
 install_bytebin() {
     echo "Installing bytebin..."
 
-    mkdir -p bytebin
+    mkdir -p bytebin || exit $?
     pushd bytebin > /dev/null
 
     # Find free port (stop the service if running)
@@ -168,22 +168,22 @@ install_bytebin() {
     BYTEBIN_PORT="$(find_free_port "$BYTEBIN_IP" "$BYTEBIN_PORT")"
 
     # Download and Copy the Files
-    wget -q --show-progress --progress=dot:mega https://ci.lucko.me/job/bytebin/lastSuccessfulBuild/artifact/target/bytebin.jar
+    wget -q --show-progress --progress=dot:mega https://ci.lucko.me/job/bytebin/lastSuccessfulBuild/artifact/target/bytebin.jar || exit $?
     echo
     jq \
         --arg ip "$BYTEBIN_IP" \
         --argjson port "$BYTEBIN_PORT" \
         '.host = $ip | .port = $port' \
-        "$INSTALLER_DIR/files/bytebin/config.json" > config.json
+        "$INSTALLER_DIR/files/bytebin/config.json" > config.json || exit $?
     sed \
         -e "s@<PATH>@$BASE_DIR/bytebin@g" \
         -e "s/<USER>/$USER/g" \
         -e "s/<GROUP>/$GROUP/g" \
-        "$INSTALLER_DIR/files/bytebin/bytebin.service" | sudo dd of=/etc/systemd/system/bytebin.service 2> /dev/null
+        "$INSTALLER_DIR/files/bytebin/bytebin.service" | sudo dd of=/etc/systemd/system/bytebin.service 2> /dev/null || exit $?
 
     # Enable and (Re)Start the Service
-    sudo systemctl daemon-reload
-    sudo systemctl enable --now bytebin.service
+    sudo systemctl daemon-reload || exit $?
+    sudo systemctl enable --now bytebin.service || exit $?
 
     popd > /dev/null
 
@@ -201,17 +201,17 @@ install_webfiles() {
         --arg url "$BYTEBIN_URL" \
         --argjson selfHosted "$SELFHOSTED" \
         '.bytebin_url = $url | .selfHosted = $selfHosted' \
-        config.json > config.json.tmp
-    mv -f config.json.tmp config.json
+        config.json > config.json.tmp || exit $?
+    mv -f config.json.tmp config.json || exit $?
 
     # Render webfiles
-    npm install
-    npm run build -- --skip-plugins eslint
+    npm install || exit $?
+    npm run build -- --skip-plugins eslint || exit $?
 
     popd > /dev/null
 
-    rm -rf webfiles
-    mv "$REPO_DIR/dist/" webfiles
+    rm -rf webfiles || exit $?
+    mv "$REPO_DIR/dist/" webfiles || exit $?
 }
 
 generate_https_cert() {
@@ -227,23 +227,23 @@ generate_https_cert() {
 
     # Configure nginx or apache for the certbot
     "$USE_NGINX"  &&
-    create_webserver_file \
+    (create_webserver_file \
         "$INSTALLER_DIR/files/nginx/luckpermsweb_header_http.conf" \
-        "$INSTALLER_DIR/files/nginx/luckpermsweb_footer_certbot.conf"  | sudo dd of="$nginx_config_file"  2> /dev/null
+        "$INSTALLER_DIR/files/nginx/luckpermsweb_footer_certbot.conf"    | sudo dd of="$nginx_config_file"  2> /dev/null || exit $?)
     "$USE_APACHE" &&
-    create_webserver_file \
+    (create_webserver_file \
         "$INSTALLER_DIR/files/apache/luckpermsweb_header_http.conf" \
         "$INSTALLER_DIR/files/apache/luckpermsweb_footer_certbot.conf" \
-        "$INSTALLER_DIR/files/apache/luckpermsweb_footer_directory.conf" | sudo dd of="$apache_config_file" 2> /dev/null
+        "$INSTALLER_DIR/files/apache/luckpermsweb_footer_directory.conf" | sudo dd of="$apache_config_file" 2> /dev/null || exit $?)
 
     ## Reload webserver
-    "$USE_NGINX"  && sudo nginx -t              && sudo nginx -s reload
-    "$USE_APACHE" && sudo apache2ctl configtest && sudo apache2ctl graceful
+    "$USE_NGINX"  && (sudo nginx -t              && sudo nginx -s reload     || exit $?)
+    "$USE_APACHE" && (sudo apache2ctl configtest && sudo apache2ctl graceful || exit $?)
 
     # Get certificate
-    sudo certbot certonly --webroot --rsa-key-size 4096 -w "$certdir" -d "$EXTERNAL_ADDRESS"
+    sudo certbot certonly --webroot --rsa-key-size 4096 -w "$certdir" -d "$EXTERNAL_ADDRESS" || exit $?
 
-    sudo rm -rf "$nginx_config_file" "$apache_config_file" "$certdir/.well-known"
+    sudo rm -rf "$nginx_config_file" "$apache_config_file" "$certdir/.well-known" || exit $?
 }
 
 configure_nginx() {
@@ -258,16 +258,16 @@ configure_nginx() {
         "$INSTALLER_DIR/files/nginx/luckpermsweb_header_$PROTOCOL.conf" \
         "$INSTALLER_DIR/files/nginx/luckpermsweb_base.conf" \
         "$("$INSTALL_BYTEBIN" && echo "$INSTALLER_DIR/files/nginx/luckpermsweb_proxy.conf")" \
-        "$INSTALLER_DIR/files/nginx/luckpermsweb_footer.conf" | sudo dd of="$nginx_config_file" 2> /dev/null
-    sudo ln -fs "../$nginx_config_file" sites-enabled/
+        "$INSTALLER_DIR/files/nginx/luckpermsweb_footer.conf" | sudo dd of="$nginx_config_file" 2> /dev/null || exit $?
+    sudo ln -fs "../$nginx_config_file" sites-enabled/ || exit $?
 
     # Reload nginx
-    sudo nginx -t && sudo nginx -s reload
+    sudo nginx -t && sudo nginx -s reload || exit $?
 
     popd > /dev/null
 
     # Ensure correct file ownership
-    sudo chgrp -R www-data webfiles
+    sudo chgrp -R www-data webfiles || exit $?
 }
 
 configure_apache() {
@@ -277,7 +277,7 @@ configure_apache() {
     pushd /etc/apache2 > /dev/null
     
     # Install modules
-    sudo a2enmod headers proxy proxy_http rewrite ssl
+    sudo a2enmod headers proxy proxy_http rewrite ssl || exit $?
 
     # Create config file
     local apache_config_name="luckpermsweb_$EXTERNAL_ADDRESS"
@@ -287,16 +287,16 @@ configure_apache() {
         "$INSTALLER_DIR/files/apache/luckpermsweb_base.conf" \
         "$("$INSTALL_BYTEBIN" && echo "$INSTALLER_DIR/files/apache/luckpermsweb_proxy.conf")" \
         "$INSTALLER_DIR/files/apache/luckpermsweb_footer.conf" \
-        "$INSTALLER_DIR/files/apache/luckpermsweb_footer_directory.conf" | sudo dd of="$apache_config_file" 2> /dev/null
-    sudo a2ensite "$apache_config_name"
+        "$INSTALLER_DIR/files/apache/luckpermsweb_footer_directory.conf" | sudo dd of="$apache_config_file" 2> /dev/null || exit $?
+    sudo a2ensite "$apache_config_name" || exit $?
 
     # Reload apache
-    sudo apache2ctl configtest && sudo apache2ctl graceful
+    sudo apache2ctl configtest && sudo apache2ctl graceful || exit $?
 
     popd > /dev/null
 
     # Ensure correct file ownership
-    sudo chgrp -R www-data webfiles
+    sudo chgrp -R www-data webfiles || exit $?
 }
 
 print_config_instructions() {

--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -24,10 +24,10 @@ deconfigure_nginx() {
     echo
 
     # Delete config files
-    sudo rm -rf /etc/nginx/sites-{available,enabled}/luckpermsweb_*.conf
+    sudo rm -rf /etc/nginx/sites-{available,enabled}/luckpermsweb_*.conf || exit $?
 
     # Reload nginx
-    [ -x /usr/sbin/nginx ] && sudo nginx -t && sudo nginx -s reload
+    [ -x /usr/sbin/nginx ] && (sudo nginx -t && sudo nginx -s reload || exit $?)
 
     echo
 }
@@ -37,10 +37,10 @@ deconfigure_apache() {
     echo
 
     # Delete config files
-    sudo rm -rf /etc/apache2/sites-{available,enabled}/luckpermsweb_*.conf
+    sudo rm -rf /etc/apache2/sites-{available,enabled}/luckpermsweb_*.conf || exit $?
 
     # Reload apache
-    [ -x /usr/sbin/apache2 ] && sudo apache2ctl configtest && sudo apache2ctl graceful
+    [ -x /usr/sbin/apache2 ] && (sudo apache2ctl configtest && sudo apache2ctl graceful || exit $?)
 
     echo
 }
@@ -58,7 +58,7 @@ remove_files() {
     echo "Removing remaining files..."
     echo
 
-    sudo rm -rf "$BASE_DIR"
+    sudo rm -rf "$BASE_DIR" || exit $?
 }
 
 print_end_message() {


### PR DESCRIPTION
This is to make sure the script doesn't continue when there are errors. When don't want this to happen everywhere that's why we don't use `set -e`.

Works well in conjunction with #275 