### PR TITLE
Properly override the file

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -179,7 +179,7 @@ install_bytebin() {
     BYTEBIN_PORT="$(find_free_port "$BYTEBIN_IP" "$BYTEBIN_PORT")"
 
     # Download and Copy the Files
-    wget -q --show-progress --progress=dot:mega https://ci.lucko.me/job/bytebin/lastSuccessfulBuild/artifact/target/bytebin.jar || exit $?
+    wget -q --show-progress --progress=dot:mega -O bytebin.jar https://ci.lucko.me/job/bytebin/lastSuccessfulBuild/artifact/target/bytebin.jar || exit $?
     echo
     jq \
         --arg ip "$BYTEBIN_IP" \


### PR DESCRIPTION
- This also gurantuees that the file always will be named `bytebin.jar`.

Overall just a tiny fix