### PR TITLE
Fix outline issue on mobile nav

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,7 @@
               Download
             </router-link>
           </li>
-          <li>
+          <li class="overlap">
             <router-link to="/wiki">
               <font-awesome icon="book" fixed-width />
               Wiki
@@ -70,7 +70,7 @@
           </ul>
         </li>
         <template v-if="!config.selfHosted">
-          <li class="external">
+          <li class="external overlap">
             <a href="https://github.com/lucko/LuckPerms" target="_blank" class="github">
               <font-awesome :icon="['fab', 'github']" fixed-width />
               <span>Github</span>
@@ -419,6 +419,10 @@ body {
       display: flex;
       position: relative;
       flex-direction: column;
+      
+      &.overlap {
+        z-index: 110;
+      }
 
       @include breakpoint($sm) {
         flex-direction: row;


### PR DESCRIPTION
On the navigation, the outline of Wiki and the GitHub button doesn't show correctly on the mobile sidebar, this can be fixed by applying a z-index that is bigger than what the ul of the tools link is (which is 100, so I applied 110).

## How it looks like
### Before
![image](https://user-images.githubusercontent.com/43016900/101141850-27825c80-3615-11eb-8776-89f0b563d00b.png)
### After
![image](https://user-images.githubusercontent.com/43016900/101141748-04f04380-3615-11eb-9776-892992a9f850.png)
