### PR TITLE
Update GitHub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/da5df752-4c7d-4a2b-8634-3eb376fd80d8/deploy-status)](https://app.netlify.com/sites/luckperms/deploys)
 [![Discord](https://img.shields.io/discord/241667244927483904.svg?logo=discord&label=)](https://discord.gg/luckperms)
 
-[LuckPerms](https://github.com/lucko/LuckPerms) is a permission plugin for Minecraft servers, written in Java.
+[LuckPerms](https://github.com/LuckPerms/LuckPerms) is a permission plugin for Minecraft servers, written in Java.
 
 LuckPermsWeb (this repository) contains the website for the project and a number of web apps which supplement the plugin, all written in HTML/JavaScript using the [Vue](https://vuejs.org/) framework.
 
@@ -20,7 +20,7 @@ Contributions are greatly appreciated! Just make a pull request with your change
 #### Cloning
 Use the following command to clone (and include the wiki submodule):
 ```sh
-git clone --recursive https://github.com/lucko/LuckPermsWeb.git
+git clone --recursive https://github.com/LuckPerms/LuckPermsWeb.git
 ```
 
 #### Setup

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,7 +71,7 @@
         </li>
         <template v-if="!config.selfHosted">
           <li class="external overlap">
-            <a href="https://github.com/lucko/LuckPerms" target="_blank" class="github">
+            <a href="https://github.com/LuckPerms/LuckPerms" target="_blank" class="github">
               <font-awesome :icon="['fab', 'github']" fixed-width />
               <span>Github</span>
             </a>
@@ -111,9 +111,9 @@
         <ul>
           <li>
             <font-awesome icon="code-branch" fixed-width />
-            <a href="https://github.com/lucko/LuckPermsWeb" target="_blank">LuckPermsWeb</a>
+            <a href="https://github.com/LuckPerms/LuckPermsWeb" target="_blank">LuckPermsWeb</a>
             @
-            <a :href="'https://github.com/lucko/LuckPermsWeb/commit/' + commitHash" target="_blank">{{ commitHash }}</a>
+            <a :href="'https://github.com/LuckPerms/LuckPermsWeb/commit/' + commitHash" target="_blank">{{ commitHash }}</a>
           </li>
           <li>
             <router-link to="/wiki/Credits">

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -106,7 +106,7 @@
             <li v-for="entry in changeLog" :key="entry.version">
               <span>
                 <a
-                  :href="`https://github.com/lucko/LuckPerms/commit/${entry.commit}`"
+                  :href="`https://github.com/LuckPerms/LuckPerms/commit/${entry.commit}`"
                   target="_blank"
                 >
                   <code>v{{ entry.version }}</code>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -78,7 +78,7 @@
             </span>
             <small>Learn how to install, setup, configure and effectively use LuckPerms</small>
           </a>
-          <a href="https://github.com/lucko/LuckPerms" class="resource">
+          <a href="https://github.com/LuckPerms/LuckPerms" class="resource">
             <span>
               <font-awesome :icon="['fab', 'github']" />
               GitHub


### PR DESCRIPTION
This changes all of the links to the new repo url (github has been nice about redirecting some of the links to the new url, but some links like the commit hash in the footer 404)