### PR TITLE
open copyright link in new tab

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -116,7 +116,7 @@
             <a :href="'https://github.com/LuckPerms/LuckPermsWeb/commit/' + commitHash" target="_blank">{{ commitHash }}</a>
           </li>
           <li>
-            <router-link to="/wiki/Credits">
+            <router-link to="/wiki/Credits" target="_blank">
               Copyright © 2017-{{ new Date().getFullYear().toString() }} LuckPerms contributors
             </router-link>
           </li>


### PR DESCRIPTION
This will make the copyright link on the bottom of the editor open in a new tab